### PR TITLE
Fix cropping when converting predictions back to patient space

### DIFF
--- a/infer_dataset.py
+++ b/infer_dataset.py
@@ -11,10 +11,30 @@ from parsing import LongitudinalDataset
 
 
 #%% run LMI WM is needed for registration
-def runLMI(registrationReference, patientFlair, patientT1, patientAffine=None, registrationMode = "WM"):
+def runLMI(
+    registrationReference,
+    patientFlair,
+    patientT1,
+    patientAffine=None,
+    registrationMode="WM",
+    padding=10,
+):
     atlasPath = "./Atlasfiles"
 
-    wmTransformed, transformedTumor, registration = tools.getAtlasSpaceLMI_InputArray(registrationReference, patientFlair, patientT1, atlasPath, getAlsoWMTrafo=True, patientAffine=patientAffine)
+    reg_ref = registrationReference
+    if padding > 0 and patientAffine is not None:
+        reg_ref, patientAffine = tools.pad_image_and_affine(registrationReference, patientAffine, padding)
+        patientFlair, _ = tools.pad_image_and_affine(patientFlair, patientAffine, padding)
+        patientT1, _ = tools.pad_image_and_affine(patientT1, patientAffine, padding)
+
+    wmTransformed, transformedTumor, registration = tools.getAtlasSpaceLMI_InputArray(
+        reg_ref,
+        patientFlair,
+        patientT1,
+        atlasPath,
+        getAlsoWMTrafo=True,
+        patientAffine=patientAffine,
+    )
 
     #%% get the LMI prediction
     prediction = np.array(tools.getNetworkPrediction(transformedTumor))[:6]
@@ -36,8 +56,20 @@ def runLMI(registrationReference, patientFlair, patientT1, patientAffine=None, r
     np.save('tumor.npy', tumor)
 
     # register back to patient space
-    predictedTumorPatientSpace = tools.convertTumorToPatientSpace(tumor, registrationReference, registration, patientAffine=patientAffine)
-    referenceBackTransformed = tools.convertTumorToPatientSpace(wmTransformed, registrationReference, registration, patientAffine=patientAffine)
+    predictedTumorPatientSpace = tools.convertTumorToPatientSpace(
+        tumor,
+        reg_ref,
+        registration,
+        patientAffine=patientAffine,
+        padding=padding,
+    )
+    referenceBackTransformed = tools.convertTumorToPatientSpace(
+        wmTransformed,
+        reg_ref,
+        registration,
+        patientAffine=patientAffine,
+        padding=padding,
+    )
 
     return predictedTumorPatientSpace, parameterDir, referenceBackTransformed
 
@@ -110,7 +142,12 @@ if __name__ == "__main__":
                 patientWM = patientWMNib.get_fdata()
                 patientWMAffine = patientWMNib.affine
 
-                predictedTumorPatientSpace, parameterDir, wmBackTransformed = runLMI(patientWM, patientFlair, patientT1, patientAffine=patientWMAffine)
+                predictedTumorPatientSpace, parameterDir, wmBackTransformed = runLMI(
+                    patientWM,
+                    patientFlair,
+                    patientT1,
+                    patientAffine=patientWMAffine,
+                )
 
                 np.save(os.path.join(resultPath, "lmi_parameters.npy"), parameterDir)
                 nib.save(nib.Nifti1Image(predictedTumorPatientSpace, patientWMAffine), os.path.join(resultPath, 'lmi_pred.nii.gz'))

--- a/infer_single.py
+++ b/infer_single.py
@@ -9,10 +9,30 @@ from simulator import runForwardSolver
 
 
 #%% run LMI WM is needed for registration
-def runLMI(registrationReference, patientFlair, patientT1, patientAffine=None, registrationMode = "WM"):
+def runLMI(
+    registrationReference,
+    patientFlair,
+    patientT1,
+    patientAffine=None,
+    registrationMode="WM",
+    padding=10,
+):
     atlasPath = "./Atlasfiles"
 
-    wmTransformed, transformedTumor, registration = tools.getAtlasSpaceLMI_InputArray(registrationReference, patientFlair, patientT1, atlasPath, getAlsoWMTrafo=True, patientAffine=patientAffine)
+    reg_ref = registrationReference
+    if padding > 0 and patientAffine is not None:
+        reg_ref, patientAffine = tools.pad_image_and_affine(registrationReference, patientAffine, padding)
+        patientFlair, _ = tools.pad_image_and_affine(patientFlair, patientAffine, padding)
+        patientT1, _ = tools.pad_image_and_affine(patientT1, patientAffine, padding)
+
+    wmTransformed, transformedTumor, registration = tools.getAtlasSpaceLMI_InputArray(
+        reg_ref,
+        patientFlair,
+        patientT1,
+        atlasPath,
+        getAlsoWMTrafo=True,
+        patientAffine=patientAffine,
+    )
 
     #%% get the LMI prediction
     prediction = np.array(tools.getNetworkPrediction(transformedTumor))[:6]
@@ -34,8 +54,20 @@ def runLMI(registrationReference, patientFlair, patientT1, patientAffine=None, r
     np.save('tumor.npy', tumor)
 
     # register back to patient space
-    predictedTumorPatientSpace = tools.convertTumorToPatientSpace(tumor, registrationReference, registration, patientAffine=patientAffine)
-    referenceBackTransformed = tools.convertTumorToPatientSpace(wmTransformed, registrationReference, registration, patientAffine=patientAffine)
+    predictedTumorPatientSpace = tools.convertTumorToPatientSpace(
+        tumor,
+        reg_ref,
+        registration,
+        patientAffine=patientAffine,
+        padding=padding,
+    )
+    referenceBackTransformed = tools.convertTumorToPatientSpace(
+        wmTransformed,
+        reg_ref,
+        registration,
+        patientAffine=patientAffine,
+        padding=padding,
+    )
 
     return predictedTumorPatientSpace, parameterDir, referenceBackTransformed
 
@@ -76,7 +108,12 @@ if __name__ == "__main__":
     patientWM = patientWMNib.get_fdata()	
     patientWMAffine = patientWMNib.affine
 
-    predictedTumorPatientSpace, parameterDir, wmBackTransformed = runLMI(patientWM, patientFlair, patientT1, patientAffine=patientWMAffine)
+    predictedTumorPatientSpace, parameterDir, wmBackTransformed = runLMI(
+        patientWM,
+        patientFlair,
+        patientT1,
+        patientAffine=patientWMAffine,
+    )
 
     np.save(os.path.join(resultPath, "lmi_parameters.npy"), parameterDir)
 

--- a/main_LMI_inference.py
+++ b/main_LMI_inference.py
@@ -10,10 +10,30 @@ from simulator import runForwardSolver
 
 
 #%% run LMI WM is needed for registration
-def runLMI(registrationReference, patientFlair, patientT1, patientAffine=None, registrationMode = "WM"):
+def runLMI(
+    registrationReference,
+    patientFlair,
+    patientT1,
+    patientAffine=None,
+    registrationMode="WM",
+    padding=10,
+):
     atlasPath = "./Atlasfiles"
 
-    wmTransformed, transformedTumor, registration = tools.getAtlasSpaceLMI_InputArray(registrationReference, patientFlair, patientT1, atlasPath, getAlsoWMTrafo=True, patientAffine=patientAffine)
+    reg_ref = registrationReference
+    if padding > 0 and patientAffine is not None:
+        reg_ref, patientAffine = tools.pad_image_and_affine(registrationReference, patientAffine, padding)
+        patientFlair, _ = tools.pad_image_and_affine(patientFlair, patientAffine, padding)
+        patientT1, _ = tools.pad_image_and_affine(patientT1, patientAffine, padding)
+
+    wmTransformed, transformedTumor, registration = tools.getAtlasSpaceLMI_InputArray(
+        reg_ref,
+        patientFlair,
+        patientT1,
+        atlasPath,
+        getAlsoWMTrafo=True,
+        patientAffine=patientAffine,
+    )
 
     #%% get the LMI prediction
     prediction = np.array(tools.getNetworkPrediction(transformedTumor))[:6]
@@ -35,8 +55,20 @@ def runLMI(registrationReference, patientFlair, patientT1, patientAffine=None, r
     np.save('tumor.npy', tumor)
 
     # register back to patient space
-    predictedTumorPatientSpace = tools.convertTumorToPatientSpace(tumor, registrationReference, registration, patientAffine=patientAffine)
-    referenceBackTransformed = tools.convertTumorToPatientSpace(wmTransformed, registrationReference, registration, patientAffine=patientAffine)
+    predictedTumorPatientSpace = tools.convertTumorToPatientSpace(
+        tumor,
+        reg_ref,
+        registration,
+        patientAffine=patientAffine,
+        padding=padding,
+    )
+    referenceBackTransformed = tools.convertTumorToPatientSpace(
+        wmTransformed,
+        reg_ref,
+        registration,
+        patientAffine=patientAffine,
+        padding=padding,
+    )
 
     return predictedTumorPatientSpace, parameterDir, referenceBackTransformed
 
@@ -59,7 +91,12 @@ if __name__ == "__main__":
     patientWM = patientWMNib.get_fdata()	
     patientWMAffine = patientWMNib.affine
 
-    predictedTumorPatientSpace, parameterDir, wmBackTransformed = runLMI(patientWM, patientFlair, patientT1, patientAffine=patientWMAffine)
+    predictedTumorPatientSpace, parameterDir, wmBackTransformed = runLMI(
+        patientWM,
+        patientFlair,
+        patientT1,
+        patientAffine=patientWMAffine,
+    )
 
     np.save("/mlcube_io1/00000_lmi_parameters.npy", parameterDir)
 

--- a/tools.py
+++ b/tools.py
@@ -379,14 +379,37 @@ def _flip_affine(affine, axis, shape):
     return flipped
 
 
-def getAtlasSpaceLMI_InputArray(registrationReference, flairSeg, T1Seg, atlasPath, getAlsoWMTrafo = False, registrationMode = "WM", patientAffine=None):
+def pad_image_and_affine(arr, affine, padding):
+    """Pad image array and update affine accordingly."""
+    if padding <= 0:
+        return arr, affine
+    padded = np.pad(arr, ((padding, padding),) * 3, mode="constant")
+    new_affine = affine.copy()
+    for i in range(3):
+        new_affine[:3, 3] -= new_affine[:3, i] * padding
+    return padded, new_affine
+
+
+def getAtlasSpaceLMI_InputArray(
+    registrationReference,
+    flairSeg,
+    T1Seg,
+    atlasPath,
+    getAlsoWMTrafo=False,
+    registrationMode="WM",
+    patientAffine=None,
+):
     print("start forward registration")
 
     #LMI works on Atlas where axis 1 is flipped
     if patientAffine is not None:
         flipped = _flip_affine(patientAffine, 1, registrationReference.shape)
-        antsWMPatient = _ants_from_numpy_with_affine(np.flip(registrationReference, axis=1), flipped)
-        antsFlairPatient = _ants_from_numpy_with_affine(np.flip(flairSeg, axis=1), flipped)
+        antsWMPatient = _ants_from_numpy_with_affine(
+            np.flip(registrationReference, axis=1), flipped
+        )
+        antsFlairPatient = _ants_from_numpy_with_affine(
+            np.flip(flairSeg, axis=1), flipped
+        )
         antsT1Patient = _ants_from_numpy_with_affine(np.flip(T1Seg, axis=1), flipped)
     else:
         #LMI works on Atlas where axis 1 is flipped
@@ -445,7 +468,13 @@ def getNetworkPrediction(transformedTumor):
 
     return convPred
 
-def convertTumorToPatientSpace(atlasTumor, patientWM, registration, patientAffine=None):
+def convertTumorToPatientSpace(
+    atlasTumor,
+    patientWM,
+    registration,
+    patientAffine=None,
+    padding=0,
+):
 
     antsTumor = ants.from_numpy(atlasTumor)
 
@@ -455,9 +484,15 @@ def convertTumorToPatientSpace(atlasTumor, patientWM, registration, patientAffin
     else:
         targetRegistration = ants.from_numpy(patientWM)
 
-    antsPredictedTumorPatientSpace = ants.apply_transforms(targetRegistration, antsTumor, registration['invtransforms'])
+    antsPredictedTumorPatientSpace = ants.apply_transforms(
+        targetRegistration, antsTumor, registration['invtransforms']
+    )
 
-    return np.flip(antsPredictedTumorPatientSpace.numpy(), axis=1)
+    predicted = np.flip(antsPredictedTumorPatientSpace.numpy(), axis=1)
+    if padding > 0:
+        predicted = predicted[padding:-padding, padding:-padding, padding:-padding]
+
+    return predicted
 
 
 


### PR DESCRIPTION
## Summary
- add helper `pad_image_and_affine`
- pad inputs before atlas registration and crop result when converting back
- update dataset and single-inference scripts
- pad data in container demo as well

## Testing
- `python -m py_compile infer_dataset.py main_LMI_inference.py infer_single.py tools.py`
- `python infer_dataset.py -h` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68500310fb9c832aa7c6320cfdfbc988