### PR TITLE
Fix cropping by conditional padding

### DIFF
--- a/infer_dataset.py
+++ b/infer_dataset.py
@@ -22,8 +22,12 @@ def runLMI(
     atlasPath = "./Atlasfiles"
 
     reg_ref = registrationReference
+    applied_padding = 0
     if padding > 0 and patientAffine is not None:
-        reg_ref, patientAffine = tools.pad_image_and_affine(registrationReference, patientAffine, padding)
+        applied_padding = padding
+        reg_ref, patientAffine = tools.pad_image_and_affine(
+            registrationReference, patientAffine, padding
+        )
         patientFlair, _ = tools.pad_image_and_affine(patientFlair, patientAffine, padding)
         patientT1, _ = tools.pad_image_and_affine(patientT1, patientAffine, padding)
 
@@ -61,14 +65,14 @@ def runLMI(
         reg_ref,
         registration,
         patientAffine=patientAffine,
-        padding=padding,
+        padding=applied_padding,
     )
     referenceBackTransformed = tools.convertTumorToPatientSpace(
         wmTransformed,
         reg_ref,
         registration,
         patientAffine=patientAffine,
-        padding=padding,
+        padding=applied_padding,
     )
 
     return predictedTumorPatientSpace, parameterDir, referenceBackTransformed

--- a/infer_single.py
+++ b/infer_single.py
@@ -20,8 +20,12 @@ def runLMI(
     atlasPath = "./Atlasfiles"
 
     reg_ref = registrationReference
+    applied_padding = 0
     if padding > 0 and patientAffine is not None:
-        reg_ref, patientAffine = tools.pad_image_and_affine(registrationReference, patientAffine, padding)
+        applied_padding = padding
+        reg_ref, patientAffine = tools.pad_image_and_affine(
+            registrationReference, patientAffine, padding
+        )
         patientFlair, _ = tools.pad_image_and_affine(patientFlair, patientAffine, padding)
         patientT1, _ = tools.pad_image_and_affine(patientT1, patientAffine, padding)
 
@@ -59,14 +63,14 @@ def runLMI(
         reg_ref,
         registration,
         patientAffine=patientAffine,
-        padding=padding,
+        padding=applied_padding,
     )
     referenceBackTransformed = tools.convertTumorToPatientSpace(
         wmTransformed,
         reg_ref,
         registration,
         patientAffine=patientAffine,
-        padding=padding,
+        padding=applied_padding,
     )
 
 

--- a/main_LMI_inference.py
+++ b/main_LMI_inference.py
@@ -21,8 +21,12 @@ def runLMI(
     atlasPath = "./Atlasfiles"
 
     reg_ref = registrationReference
+    applied_padding = 0
     if padding > 0 and patientAffine is not None:
-        reg_ref, patientAffine = tools.pad_image_and_affine(registrationReference, patientAffine, padding)
+        applied_padding = padding
+        reg_ref, patientAffine = tools.pad_image_and_affine(
+            registrationReference, patientAffine, padding
+        )
         patientFlair, _ = tools.pad_image_and_affine(patientFlair, patientAffine, padding)
         patientT1, _ = tools.pad_image_and_affine(patientT1, patientAffine, padding)
 
@@ -60,14 +64,14 @@ def runLMI(
         reg_ref,
         registration,
         patientAffine=patientAffine,
-        padding=padding,
+        padding=applied_padding,
     )
     referenceBackTransformed = tools.convertTumorToPatientSpace(
         wmTransformed,
         reg_ref,
         registration,
         patientAffine=patientAffine,
-        padding=padding,
+        padding=applied_padding,
     )
 
     return predictedTumorPatientSpace, parameterDir, referenceBackTransformed


### PR DESCRIPTION
## Summary
- avoid cropping volumes when no padding was applied
- use the actual padding amount in the LMI helper scripts

## Testing
- `python -m py_compile main_LMI_inference.py infer_single.py infer_dataset.py tools.py`

------
https://chatgpt.com/codex/tasks/task_e_6853cfe36070832a826042570512c11c